### PR TITLE
A fix for out of boundaries image reads of Multiscale denoiser

### DIFF
--- a/include/bcd/core/DeepImage.h
+++ b/include/bcd/core/DeepImage.h
@@ -184,6 +184,9 @@ namespace bcd
 		scalar* getDataPtr();
 		const scalar* getDataPtr() const;
 
+		/// @brief Returns a clamped position with the width and height of the image
+		PixelPosition clamp(const PixelPosition& pos) const;
+			
 		/// @brief Returns the 1D storage index in the buffer from 3 coordinates
 		int glueIndices(int i_line, int i_column, int i_dimensionIndex) const;
 

--- a/include/bcd/core/DeepImage.hpp
+++ b/include/bcd/core/DeepImage.hpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <cassert>
 
 namespace bcd
 {
@@ -376,8 +377,21 @@ namespace bcd
 	inline const scalar* DeepImage< scalar >::getDataPtr() const { return m_data.data(); }
 
 	template < typename scalar >
+	inline PixelPosition DeepImage< scalar >::clamp(const PixelPosition& pos) const {
+		return PixelPosition(std::max(0, std::min(pos.m_line, m_height - 1)),
+				std::max(0, std::min(pos.m_column, m_width - 1)));
+	}
+
+	template < typename scalar >
 	inline int DeepImage< scalar >::glueIndices(int i_line, int i_column, int i_dimensionIndex) const
 	{
+		assert(i_line >= 0);
+		assert(i_line < m_height);
+		assert(i_column >= 0);
+		assert(i_column < m_width);
+		assert(i_dimensionIndex >= 0);
+		assert(i_dimensionIndex < m_depth);		
+
 		return i_line * m_widthTimesDepth + i_column * m_depth + i_dimensionIndex;
 	}
 
@@ -386,6 +400,13 @@ namespace bcd
 			int i_width, int i_height, int i_depth,
 			int i_line, int i_column, int i_dimensionIndex)
 	{
+		assert(i_line >= 0);
+		assert(i_line < i_height);
+		assert(i_column >= 0);
+		assert(i_column < i_width);
+		assert(i_dimensionIndex >= 0);
+		assert(i_dimensionIndex < i_depth);	
+
 		return (i_line * i_width + i_column) * i_depth + i_dimensionIndex;
 	}
 

--- a/src/core/MultiscaleDenoiser.cpp
+++ b/src/core/MultiscaleDenoiser.cpp
@@ -257,9 +257,9 @@ namespace bcd
 			for(col = 0; col < downscaledWidth; ++col)
 			{
 				p1 = PixelPosition(2 * line, 2 * col);
-				p2 = p1 + PixelVector(1,0);
-				p3 = p1 + PixelVector(0,1);
-				p4 = p1 + PixelVector(1,1);
+				p2 = i_rImage.clamp(p1 + PixelVector(1,0));
+				p3 = i_rImage.clamp(p1 + PixelVector(0,1));
+				p4 = i_rImage.clamp(p1 + PixelVector(1,1));
 				for(z = 0; z < depth; ++z)
 					uImage->set(line, col, z,
 							i_rImage.get(p1, z) + i_rImage.get(p2, z) + i_rImage.get(p3, z) + i_rImage.get(p4, z));
@@ -284,9 +284,9 @@ namespace bcd
 			for(col = 0; col < downscaledWidth; ++col)
 			{
 				p1 = PixelPosition(2 * line, 2 * col);
-				p2 = p1 + PixelVector(1,0);
-				p3 = p1 + PixelVector(0,1);
-				p4 = p1 + PixelVector(1,1);
+				p2 = i_rImage.clamp(p1 + PixelVector(1,0));
+				p3 = i_rImage.clamp(p1 + PixelVector(0,1));
+				p4 = i_rImage.clamp(p1 + PixelVector(1,1));
 				for(z = 0; z < depth; ++z)
 					uImage->set(line, col, z,
 							0.25f * (i_rImage.get(p1, z) + i_rImage.get(p2, z) + i_rImage.get(p3, z) + i_rImage.get(p4, z)));
@@ -314,9 +314,9 @@ namespace bcd
 			for(col = 0; col < downscaledWidth; ++col)
 			{
 				p1 = PixelPosition(2 * line, 2 * col);
-				p2 = p1 + PixelVector(1,0);
-				p3 = p1 + PixelVector(0,1);
-				p4 = p1 + PixelVector(1,1);
+				p2 = i_rSampleCovarianceImage.clamp(p1 + PixelVector(1,0));
+				p3 = i_rSampleCovarianceImage.clamp(p1 + PixelVector(0,1));
+				p4 = i_rSampleCovarianceImage.clamp(p1 + PixelVector(1,1));
 				n1 = i_rNbOfSamplesImage.get(p1, 0);
 				n2 = i_rNbOfSamplesImage.get(p2, 0);
 				n3 = i_rNbOfSamplesImage.get(p3, 0);
@@ -353,9 +353,9 @@ namespace bcd
 			for(col = 0; col < downscaledWidth; ++col)
 			{
 				p1 = PixelPosition(2 * line, 2 * col);
-				p2 = p1 + PixelVector(1,0);
-				p3 = p1 + PixelVector(0,1);
-				p4 = p1 + PixelVector(1,1);
+				p2 = i_rSampleCovarianceImage.clamp(p1 + PixelVector(1,0));
+				p3 = i_rSampleCovarianceImage.clamp(p1 + PixelVector(0,1));
+				p4 = i_rSampleCovarianceImage.clamp(p1 + PixelVector(1,1));
 				w1 = i_rWeightImage.get(p1, 0);
 				w2 = i_rWeightImage.get(p2, 0);
 				w3 = i_rWeightImage.get(p3, 0);
@@ -390,9 +390,9 @@ namespace bcd
 			for(col = 0; col < downscaledWidth; ++col)
 			{
 				p1 = PixelPosition(2 * line, 2 * col);
-				p2 = p1 + PixelVector(1,0);
-				p3 = p1 + PixelVector(0,1);
-				p4 = p1 + PixelVector(1,1);
+				p2 = i_rWeightImage.clamp(p1 + PixelVector(1,0));
+				p3 = i_rWeightImage.clamp(p1 + PixelVector(0,1));
+				p4 = i_rWeightImage.clamp(p1 + PixelVector(1,1));
 				w1 = i_rWeightImage.get(p1, 0);
 				w2 = i_rWeightImage.get(p2, 0);
 				w3 = i_rWeightImage.get(p3, 0);
@@ -496,10 +496,17 @@ namespace bcd
 				adjacentLine = clampPositiveInteger(line + ((upscaledLine % 2) * 2 - 1), height);
 				adjacentCol = clampPositiveInteger(col + ((upscaledCol % 2) * 2 - 1), width);
 				for(z = 0; z < depth; ++z)
+				{
+					const PixelPosition p1 = i_rImage.clamp(PixelPosition(line, col));
+					const PixelPosition p2 = i_rImage.clamp(PixelPosition(line, adjacentCol));
+					const PixelPosition p3 = i_rImage.clamp(PixelPosition(adjacentLine, col));
+					const PixelPosition p4 = i_rImage.clamp(PixelPosition(adjacentLine, adjacentCol));
+
 					o_rInterpolatedImage.set(upscaledLine, upscaledCol, z,
-							mainPixelWeight * i_rImage.get(line, col, z) +
-							adjacentPixelWeight * (i_rImage.get(line, adjacentCol, z) + i_rImage.get(adjacentLine, col, z)) +
-							diagonalPixelWeight * i_rImage.get(adjacentLine, adjacentCol, z));
+							mainPixelWeight * i_rImage.get(p1, z) +
+							adjacentPixelWeight * (i_rImage.get(p2, z) + i_rImage.get(p3, z)) +
+							diagonalPixelWeight * i_rImage.get(p4, z));
+				}
 			}
 
 	}
@@ -522,9 +529,9 @@ namespace bcd
 			for(col = 0; col < downscaledWidth; ++col)
 			{
 				p1 = PixelPosition(2 * line, 2 * col);
-				p2 = p1 + PixelVector(1,0);
-				p3 = p1 + PixelVector(0,1);
-				p4 = p1 + PixelVector(1,1);
+				p2 = i_rImage.clamp(p1 + PixelVector(1,0));
+				p3 = i_rImage.clamp(p1 + PixelVector(0,1));
+				p4 = i_rImage.clamp(p1 + PixelVector(1,1));
 				for(z = 0; z < depth; ++z)
 					o_rDownscaledImage.set(line, col, z,
 							0.25f * (i_rImage.get(p1, z) + i_rImage.get(p2, z) + i_rImage.get(p3, z) + i_rImage.get(p4, z)));


### PR DESCRIPTION
BCD Multiscale denoiser will access out of image boundaries for any image with width and/or height that is not a multiples of 2^(scale-1).

The result will be a crash or artifacts like:

![rgb_imagepipeline_2](https://user-images.githubusercontent.com/3247881/39992285-9630f83c-5772-11e8-9200-f62ba0f81d24.png)

This pull request includes a simple fix for the problem and produces correct results:

![rgb_imagepipeline_2-fix](https://user-images.githubusercontent.com/3247881/39992324-b05489fe-5772-11e8-9d8e-0f800f78db04.png)

P.S. thanks for your work and making BCD demo sources publicly available (it should be mandatory for any paper !).
It is currently used in [LuxCoreRender](https://luxcorerender.org) v2.1alpha0 for CPU and GPU (i.e. OpenCL) renderings, for path tracing and bidirectional path tracing (even if the application to BiDir is a bit "stretched").
